### PR TITLE
docs(MOBILE_ACTIONS): fix navigate_back docstring ('Return to home page' was wrong)

### DIFF
--- a/preprocessing/prompts.py
+++ b/preprocessing/prompts.py
@@ -80,7 +80,7 @@ def wait(seconds: float) -> str:
 MOBILE_ACTIONS = """
 def navigate_back() -> str:
     \"\"\"
-    Return to home page
+    Navigates back to the previous screen.
     \"\"\"
 
 def open_app(app_name: str) -> str:


### PR DESCRIPTION
## Summary

In \`preprocessing/prompts.py\` the \`MOBILE_ACTIONS\` prompt declared:

\`\`\`python
def navigate_back() -> str:
    \"\"\"
    Return to home page
    \"\"\"
\`\`\`

But \`navigate_back\` maps to \`mobile.back()\` per \`preprocessing/action_conversion.py\` (\`mobile.back() -> navigate_back()\`), which triggers the Android back button — not the home button. Left as-is, the model is told the function goes to *home*, which would produce incorrect actions.

Updated the docstring to \`Navigates back to the previous screen.\`, consistent with the equivalent desktop-actions \`navigate_back\` docstring a few lines above.

Closes #3

## Testing

Prompt-string change only. No code path touched.